### PR TITLE
Confusion matrix feature

### DIFF
--- a/backend/statistics.py
+++ b/backend/statistics.py
@@ -41,8 +41,9 @@ class Conversation(Base):
     model_name = Column(String(255))
     source = Column(String(255))
     response_time = Column(Integer)
-    correct = Column(Boolean, nullable=True)  
+    correct = Column(Boolean, nullable=True)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=True)
+    answerable = Column(Boolean, nullable=True)
     common_topics = Column(Text)
     date = Column(DateTime(timezone=True), default=datetime.utcnow)
 
@@ -77,8 +78,9 @@ def insert_conversation(
     citations,
     model_name,
     source,
-    response_time, 
+    response_time,
     user_id,
+    answerable=None, 
     correct=None,  
     common_topics=""
 ):
@@ -91,8 +93,9 @@ def insert_conversation(
             model_name=model_name,
             source=source,
             response_time=response_time,
-            correct=correct, 
+            correct=correct,
             user_id=user_id,
+            answerable=answerable,
             common_topics=common_topics
         )
         session.add(new_conversation)

--- a/frontend/streamlit.py
+++ b/frontend/streamlit.py
@@ -39,7 +39,7 @@ def main():
 
         st.sidebar.empty()
         display_confusion_matrix()
-        update_and_display_statistics()
+        # update_and_display_statistics()
 
         # Display messages
         for message in st.session_state.messages:

--- a/frontend/streamlit.py
+++ b/frontend/streamlit.py
@@ -1,74 +1,21 @@
 import os
 import time
 import streamlit as st
-import yake
 from .pdf import serve_pdf
 from backend.inference import chat_completion
 from backend.statistics import (
     init_user_session,
     update_user_session,
     insert_conversation,
-    get_statistics,
-    toggle_correctness
 )
-
-def load_css():
-    """Load CSS styles"""
-    css_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "styles", "style.css")
-    with open(css_file) as f:
-        st.markdown(f'<style>{f.read()}</style>', unsafe_allow_html=True)
-
-def update_and_display_statistics():
-    """Updates statistics report in the left sidebar based on selected period (Daily/Overall)"""
-    st.sidebar.markdown("<h1 class='title-stat'>Statistics Reports</h1>", unsafe_allow_html=True)
-    stat_period = st.sidebar.radio(
-        "Statistics period (Daily or Overall)",
-        ('Daily', 'Overall'),
-        key="stats_period",
-        label_visibility="hidden",
-        horizontal=True
-    )
-    stats = get_statistics(stat_period)
-    st.session_state.statistics = stats
-    statistics = [
-        f"Number of questions: {stats['num_questions']}",
-        f"Number of correct answers: {stats['num_correct']}",
-        f"Number of incorrect answers: {stats['num_incorrect']}",
-        f"User engagement metrics: {stats['user_engagement']:.2f} seconds",
-        f"Response time analysis: {stats['avg_response_time']:.2f} seconds",
-        f"Accuracy rate: {stats['accuracy_rate']:.2f}%",
-        f"Satisfaction rate: {stats['satisfaction_rate']:.2f}%",
-        f"Common topics or keywords: {stats['common_topics']}",
-        f"Improvement over time",
-        f"Feedback summary"
-    ]
-    for stat in statistics:
-        st.sidebar.markdown(f"""
-            <div class='btn-stat-container'>
-                <span class="btn-stat">{stat}</span>
-            </div>
-        """, unsafe_allow_html=True)
-
-def handle_feedback(conversation_id):
-    """Handle feedback button click"""
-    feedback_value = st.session_state.get(f"feedback_{conversation_id}", None)
-    if feedback_value is not None:
-        toggle_correctness(conversation_id, feedback_value == 1)
-        update_user_session(st.session_state.user_id)
-
-def extract_keywords(texts):
-    """Extract top N keywords from text using YAKE"""
-    extractor = yake.KeywordExtractor(lan="en", n=1, features=None)
-    ignore_words = {
-        'pdf', 'education', 'engineering', 'software', 'practitioner', 'file', 'textbook.pdf', 'swebok', 'app', 'view',
-        'details', 'level', 'target', 'blank', 'page', 'href', 'pressman', 'detail', 'system', 'systems'
-    }
-    keywords = set()
-    for text in texts:
-        extracted = dict(extractor.extract_keywords(text)).keys()
-        filtered_keywords = {word.lower() for word in extracted if word.lower() not in ignore_words}
-        keywords.update(filtered_keywords)
-    return ", ".join(list(keywords))
+from .utils import (
+    baseline_questions,
+    load_css,
+    update_and_display_statistics,
+    display_confusion_matrix,
+    handle_feedback,
+    extract_keywords
+)
 
 def main():
     """Main Streamlit app logic"""
@@ -91,6 +38,7 @@ def main():
             print(f"Creating user#{st.session_state.user_id}")
 
         st.sidebar.empty()
+        display_confusion_matrix()
         update_and_display_statistics()
 
         # Display messages
@@ -136,6 +84,7 @@ def main():
                 response_time=response_time,
                 correct=None,
                 user_id=st.session_state.user_id,
+                answerable = baseline_questions.get(prompt, None),
                 common_topics=keywords
             )
 
@@ -152,6 +101,3 @@ def main():
 
             update_user_session(st.session_state.user_id)
             st.rerun()
-
-if __name__ == "__main__":
-    main()

--- a/frontend/utils.py
+++ b/frontend/utils.py
@@ -1,0 +1,102 @@
+import os
+import yake
+import streamlit as st
+from backend.statistics import (
+    update_user_session,
+    get_statistics,
+    toggle_correctness
+)
+
+baseline_questions = {
+    # 10 Answerable questions
+    "Who is Hironori Washizaki?": True,
+    "What is software quality?": True,
+    "What is agile approach?": True,
+    "How does the Agile approach impact software quality?": True,
+    "What is software testing process?": True,
+    "What is ROI?": True,
+    "What is a Quality Management System (QMS) in software?": True,
+    "What are some key challenges to ensuring software quality?": True,
+    "How do risk management and SQA interact in projects?": True,
+    "How does testability affect software testing processes?": True,
+
+    # 10 Unanswerable Questions
+    "How many defects will occur in a specific software project?": False,
+    "What is the cost of nonconformance for a project?": False,
+    "How will a new process affect software defect rates?": False,
+    "What is the probability of a defect reoccurring in software?": False,
+    "How long will it take to resolve defects from an audit?": False,
+    "What level of software quality is `good enough` for stakeholders?": False,
+    "What is the future impact of AI on software quality standards?": False,
+    "What ROI will be achieved through additional SQA measures?": False,
+    "What specific changes improve software quality across all projects?": False,
+    "How many resources are needed to achieve a quality level?": False
+}
+
+def search_questions(search_term: str):
+    """Search function for the searchbox"""
+    if not search_term:
+        return list(baseline_questions.keys())
+    return [question for question in baseline_questions.keys() if search_term.lower() in question.lower()]
+
+def load_css():
+    """Load CSS styles"""
+    css_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "styles", "style.css")
+    with open(css_file) as f:
+        st.markdown(f'<style>{f.read()}</style>', unsafe_allow_html=True)
+
+def update_and_display_statistics():
+    """Updates statistics report in the left sidebar based on selected period (Daily/Overall)"""
+    st.sidebar.markdown("<h1 class='title-stat'>Statistics Reports</h1>", unsafe_allow_html=True)
+    stat_period = st.sidebar.radio(
+        "Statistics period (Daily or Overall)",
+        ('Daily', 'Overall'),
+        key="stats_period",
+        label_visibility="hidden",
+        horizontal=True
+    )
+    stats = get_statistics(stat_period)
+    st.session_state.statistics = stats
+    statistics = [
+        f"Number of questions: {stats['num_questions']}",
+        f"Number of correct answers: {stats['num_correct']}",
+        f"Number of incorrect answers: {stats['num_incorrect']}",
+        f"User engagement metrics: {stats['user_engagement']:.2f} seconds",
+        f"Response time analysis: {stats['avg_response_time']:.2f} seconds",
+        f"Accuracy rate: {stats['accuracy_rate']:.2f}%",
+        f"Satisfaction rate: {stats['satisfaction_rate']:.2f}%",
+        f"Common topics or keywords: {stats['common_topics']}",
+        f"Improvement over time",
+        f"Feedback summary"
+    ]
+    for stat in statistics:
+        st.sidebar.markdown(f"""
+            <div class='btn-stat-container'>
+                <span class="btn-stat">{stat}</span>
+            </div>
+        """, unsafe_allow_html=True)
+
+def display_confusion_matrix():
+    """Display confusion matrix and evaluation metrics"""
+    st.sidebar.markdown("<h1 class='title-stat'>Confusion Matrix</h1>", unsafe_allow_html=True)
+
+def handle_feedback(conversation_id):
+    """Handle feedback button click"""
+    feedback_value = st.session_state.get(f"feedback_{conversation_id}", None)
+    if feedback_value is not None:
+        toggle_correctness(conversation_id, feedback_value == 1)
+        update_user_session(st.session_state.user_id)
+
+def extract_keywords(texts):
+    """Extract top N keywords from text using YAKE"""
+    extractor = yake.KeywordExtractor(lan="en", n=1, features=None)
+    ignore_words = {
+        'pdf', 'education', 'engineering', 'software', 'practitioner', 'file', 'textbook.pdf', 'swebok', 'app', 'view',
+        'details', 'level', 'target', 'blank', 'page', 'href', 'pressman', 'detail', 'system', 'systems'
+    }
+    keywords = set()
+    for text in texts:
+        extracted = dict(extractor.extract_keywords(text)).keys()
+        filtered_keywords = {word.lower() for word in extracted if word.lower() not in ignore_words}
+        keywords.update(filtered_keywords)
+    return ", ".join(list(keywords))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ langchain
 langchain-community
 langchain-huggingface
 langchain-mistralai
+pandas
+plotly
 pypdf
 python-dotenv
 roman


### PR DESCRIPTION
Added a confusion matrix and performance metrics reports to sidebar

Changes:
- Temporarily removed statistics reports
- Added 20 baseline questions
- Updated database to store `answerable` value
- Using plotly to display the confusion matrix
- Added `utils.py` and moved streamlit functions there

Note:
- We have to updated the styling for this
- Confusion matrix will only display when atleast one of the 20 baseline questions is in the DB